### PR TITLE
build: adds get & update version scripts

### DIFF
--- a/getVersion.sh
+++ b/getVersion.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+group="${1:-fish.focus.uvms.docker}"
+artifact="${2:-uvms-docker-wildfly-unionvms}"
+
+curl -s https://search.maven.org/solrsearch/select\?q\=g:$group+AND+a:$artifact | grep -Po 'latestVersion.:.\K[^"]*'
+

--- a/updateMkdocs.sh
+++ b/updateMkdocs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+variable="${1}"
+version="${2}"
+
+sed -i 's|'"$variable"':.*$|'"$variable"': '"$version"'|' mkdocs.yml
+


### PR DESCRIPTION
Running getVersion.sh will return the latest released UVMS version. That can then be used to update parameters in mkdocs using e.g.

./updateMkdocs.sh uvms_version 1.2.3