### PR TITLE
ci: fixes version prefix for tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,6 +103,6 @@ jobs:
         run: |
           git config user.name uvmsci
           git config user.email uvmsci@gmail.com
-          git tag -f -a "${VERSION}" -m "Release ${VERSION} of documentation image"
+          git tag -f -a "docker-image-${VERSION}" -m "Release ${VERSION} of documentation image"
           git push origin ${VERSION}
 

--- a/getNextDockerImageVersion.sh
+++ b/getNextDockerImageVersion.sh
@@ -14,7 +14,7 @@ print_version () {
     echo -n "$dockerfile_version.${1:-1}"
 }
 
-latest_tag=$(git describe --tags --match="docker-image-*" --abbrev=0 HEAD 2>&1)
+latest_tag=$(git describe --tags --match="docker-image-*" --abbrev=0 HEAD | sed 's/docker-image-//' 2>&1)
 
 dockerfile_version=$(grep -m 1 -o ':.*' $SCRIPTPATH/Dockerfile | tr -d ':')
 


### PR DESCRIPTION
The tags should be prefixed with docker-image to differentiate them with releases of the documentation.