### PR TITLE
ci: removes updating workflow file

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -32,10 +32,14 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v4
 
+      - name: Fetch all tags
+        run: git fetch --depth=1 --tags
+
       - name: Set version and documentation aliases
         id: set-doc-aliases
         if: github.event_name != 'workflow_dispatch'
         run: |
+          echo "UVMS_MKDOCS_IMAGE_VERSION=$(git tag -l --sort=-taggerdate 'docker-image-*' | head -n1 | sed 's/docker-image-//' 2>&1)" >> $GITHUB_ENV
           echo "UVMS_FULL_VERSION=$(./getVersion.sh)" >> $GITHUB_ENV
           echo "UVMS_VERSION_AND_ALIASES=dev" >> $GITHUB_ENV
 
@@ -45,6 +49,7 @@ jobs:
         run: |
           export FULL_VERSION=${{ inputs.version }}
           export VERSION_WITHOUT_PATCH_PART=$(echo "$FULL_VERSION" | grep -Po '(\d+\.\d+)' | head -n1)
+          echo "UVMS_MKDOCS_IMAGE_VERSION=$(git tag -l --sort=-taggerdate 'docker-image-*' | head -n1 | sed 's/docker-image-//' 2>&1)" >> $GITHUB_ENV
           echo "UVMS_GIT_TAG=$(./getNextVersion.sh uvms $FULL_VERSION)" >> $GITHUB_ENV
           echo "UVMS_FULL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
           echo "UVMS_VERSION_AND_ALIASES=$VERSION_WITHOUT_PATCH_PART latest" >> $GITHUB_ENV
@@ -69,7 +74,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           registry: docker.io
-          image: uvms/mkdocs-material:9.5.50.3
+          image: uvms/mkdocs-material:${{ env.UVMS_MKDOCS_IMAGE_VERSION }}
           options: -v ${{ github.workspace }}:/docs -w /docs
           run: |
             mkdocs build
@@ -80,7 +85,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           registry: docker.io
-          image: uvms/mkdocs-material:9.5.50.3
+          image: uvms/mkdocs-material:${{ env.UVMS_MKDOCS_IMAGE_VERSION }}
           options: -v ${{ github.workspace }}:/docs -w /docs
           run: |
             mike deploy -u ${{ env.UVMS_VERSION_AND_ALIASES }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,8 +17,6 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      # for git tag
       contents: write
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
@@ -109,14 +107,4 @@ jobs:
           git config user.email uvmsci@gmail.com
           git tag -f -a "${TAG}" -m "build: release ${VERSION} of documentation image"
           git push origin ${TAG}
-
-      - name: Update ci image version
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          VERSION: ${{ env.UVMS_IMAGE_VERSION }}
-        run: |
-          ./updateVersion.sh image "uvms/mkdocs-material:${VERSION}" ".github/workflows/build-documentation.yml"
-          git add ".github/workflows/build-documentation.yml"
-          git commit -am "ci: updates container version to ${VERSION}"
-          git push origin HEAD
 


### PR DESCRIPTION
$GITHUB_TOKEN doesn't have support for updating workflows. A PAT or app is needed instead which requires more maintenance. This change opts for the third option of dynamically grabbing the latest version from git.